### PR TITLE
Change Pomodoro timer default to 20 minutes

### DIFF
--- a/june-2025/xpander.ai/pomodoro-timer/index.html
+++ b/june-2025/xpander.ai/pomodoro-timer/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="timer" id="timer">25:00</div>
+  <div class="timer" id="timer">20:00</div>
   <div class="controls">
     <button id="start">Start</button>
     <button id="pause">Pause</button>

--- a/june-2025/xpander.ai/pomodoro-timer/script.js
+++ b/june-2025/xpander.ai/pomodoro-timer/script.js
@@ -1,4 +1,4 @@
-let duration = 25 * 60;
+let duration = 20 * 60;
 let timerId;
 const display = document.getElementById("timer");
 
@@ -30,7 +30,7 @@ document.getElementById("pause").addEventListener("click", () => {
 document.getElementById("reset").addEventListener("click", () => {
   clearInterval(timerId);
   timerId = null;
-  duration = 25 * 60;
+  duration = 20 * 60;
   updateDisplay(duration);
 });
 


### PR DESCRIPTION
This PR updates the existing Pomodoro timer app (located at june-2025/xpander.ai/pomodoro-timer/) to use a 20-minute default timer instead of 25 minutes. All changes are in a single commit. The timer now starts at 20:00, and all related logic and display have been updated accordingly.